### PR TITLE
use TARGET_ARCH instead of hardcoded arch in paths

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -16,7 +16,7 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := sodium
-LOCAL_SRC_FILES := /installs/libsodium/libsodium-android-arm/lib/libsodium.a #/installs/libsodium/libsodium-android-x86/lib/libsodium.a
+LOCAL_SRC_FILES := /installs/libsodium/libsodium-android-$(TARGET_ARCH)/lib/libsodium.a #/installs/libsodium/libsodium-android-(x86|arm|mips)/lib/libsodium.a
 include $(PREBUILT_STATIC_LIBRARY)
 
 include $(CLEAR_VARS)
@@ -27,7 +27,7 @@ sodium_wrap.c
 
 LOCAL_CFLAGS   += -Wall -g -pedantic -std=c99
 
-LOCAL_C_INCLUDES += /installs/libsodium/libsodium-android-arm/include /installs/libsodium/libsodium-android-arm/include/sodium
+LOCAL_C_INCLUDES += /installs/libsodium/libsodium-android-$(TARGET_ARCH)/include /installs/libsodium/libsodium-android-$(TARGET_ARCH)/include/sodium
 LOCAL_STATIC_LIBRARIES += android_native_app_glue sodium
 #LOCAL_LDLIBS += -llog -lsodium
 


### PR DESCRIPTION
use $(TARGET_ARCH) inside Android.mk to include prebuilts and includes depending on the target architecture.
