### PR TITLE
Rename libtestjni.so to libkaliumjni.so

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ before_script:
   - find /home/travis/build/joshjdevl/kalium-jni/swig-2.0.10/vendor
   - sudo cp /home/travis/build/joshjdevl/kalium-jni/libsodium-0.4.1/vendor/lib/libsodium.* /usr/lib
   - /home/travis/build/joshjdevl/kalium-jni/swig-2.0.10/vendor/bin/swig -java sodium.i
-  - gcc -I/home/travis/build/joshjdevl/kalium-jni/libsodium-0.4.1/vendor/include -I/home/travis/build/joshjdevl/kalium-jni/libsodium-0.4.1/vendor/sodium -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux sodium_wrap.c -shared -fPIC -L/usr/lib -lsodium -o /home/travis/build/joshjdevl/kalium-jni/libsodium-0.4.1/vendor/lib/libtestjni.so
-  - sudo cp /home/travis/build/joshjdevl/kalium-jni/libsodium-0.4.1/vendor/lib/libtestjni.so /usr/lib/libtestjni.so
+  - gcc -I/home/travis/build/joshjdevl/kalium-jni/libsodium-0.4.1/vendor/include -I/home/travis/build/joshjdevl/kalium-jni/libsodium-0.4.1/vendor/sodium -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux sodium_wrap.c -shared -fPIC -L/usr/lib -lsodium -o /home/travis/build/joshjdevl/kalium-jni/libsodium-0.4.1/vendor/lib/libkaliumjni.so
+  - sudo cp /home/travis/build/joshjdevl/kalium-jni/libsodium-0.4.1/vendor/lib/libkaliumjni.so /usr/lib/libkaliumjni.so
   - ls -ltr /usr/lib
 
 

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -21,7 +21,7 @@ include $(PREBUILT_STATIC_LIBRARY)
 
 include $(CLEAR_VARS)
 
-LOCAL_MODULE    := testjni
+LOCAL_MODULE    := kaliumjni
 LOCAL_SRC_FILES :=  \
 sodium_wrap.c
 

--- a/jni/compile.sh
+++ b/jni/compile.sh
@@ -18,10 +18,10 @@ rm -f *.so
 swig -java -package org.abstractj.kalium -outdir ../src/main/java/org/abstractj/kalium sodium.i
 
 
-jnilib=libtestjni.so
+jnilib=libkaliumjni.so
 destlib=/usr/lib
 if uname -a | grep -q -i darwin; then
-  jnilib=libtestjni.jnilib
+  jnilib=libkaliumjni.jnilib
   destlib=/usr/lib/java
 fi
 echo $jnilib
@@ -29,6 +29,6 @@ echo $destlib
 
 sudo cp /usr/local/lib/libsodium.* /usr/lib
 gcc -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux sodium_wrap.c -shared -fPIC -L/usr/lib -lsodium -o $jnilib
-sudo rm -f /usr/lib/libtestjni.so 
-sudo cp libtestjni.so $destlib
+sudo rm -f /usr/lib/libkaliumjni.so 
+sudo cp libkaliumjni.so $destlib
 

--- a/src/main/java/org/abstractj/kalium/NaCl.java
+++ b/src/main/java/org/abstractj/kalium/NaCl.java
@@ -33,6 +33,6 @@ public class NaCl {
     }
 
     static {
-        System.loadLibrary("testjni");
+        System.loadLibrary("kaliumjni");
     }
 }


### PR DESCRIPTION
libtestjni is a pretty unhelpful library name. How about libkaliumjni?
