### PR TITLE
Clarify compile.sh usage

### DIFF
--- a/jni/compile.sh
+++ b/jni/compile.sh
@@ -31,7 +31,15 @@ sudo cp /usr/local/lib/libsodium.* /usr/lib
 
 #In order to compile for arm/armv7/x86/mips you should build your own standalone android-toolchain as in libsodium:android-build.sh
 #https://github.com/jedisct1/libsodium/blob/master/dist-build/android-build.sh
-#And then use gcc binary from there.
+#And then use gcc binary from there. 
+#Example(arm):
+#/installs/libsodium/android-toolchain-arm/arm-linux-androideabi/bin/gcc -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux -I/installs/libsodium/libsodium-android-arm/include sodium_wrap.c -shared -fPIC -L/installs/libsodium/libsodium-android-arm/lib -lsodium -o $jnilib
+#Example(arm7):
+#/installs/libsodium/android-toolchain-armv7/arm-linux-androideabi/bin/gcc -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux -I/installs/libsodium/libsodium-android-armv7/include sodium_wrap.c -shared -fPIC -L/installs/libsodium/libsodium-android-armv7/lib -lsodium -o $jnilib
+#Example(mips):
+#/installs/libsodium/android-toolchain-mips/mipsel-linux-android/bin/gcc -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux -I/installs/libsodium/libsodium-android-mips/include sodium_wrap.c -shared -fPIC -L/installs/libsodium/libsodium-android-mips/lib -lsodium -o $jnilib
+#Example(x86):
+#/installs/libsodium/android-toolchain-x86/i686-linux-android/bin/gcc -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux -I/installs/libsodium/libsodium-android-x86/include sodium_wrap.c -shared -fPIC -L/installs/libsodium/libsodium-android-x86/lib -lsodium -o $jnilib
 gcc -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux sodium_wrap.c -shared -fPIC -L/usr/lib -lsodium -o $jnilib
 sudo rm -f /usr/lib/libkaliumjni.so 
 sudo cp libkaliumjni.so $destlib


### PR DESCRIPTION
I'm not really into C programming, so it took me about a day to get how to compile libkaliumjni.so for different platforms. 
Moreover, compile.sh and dockerfile confused me a lot -- in compile.sh default gcc was used, in dockerfile: unused .so from dist_build scripts.
