### PR TITLE
Exposed SigningKey's verify key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@ target/
 hs_err*
 *.*~
 *.class
+jni/swig-2.0.10
+libs/armeabi
+obj
+jni

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,1 +1,3 @@
 APP_STL := stlport_static
+
+APP_ABI := armeabi armeabi-v7a x86 mips

--- a/src/main/java/org/abstractj/kalium/keys/SigningKey.java
+++ b/src/main/java/org/abstractj/kalium/keys/SigningKey.java
@@ -35,6 +35,8 @@ public class SigningKey {
 
     private final byte[] seed;
     private final byte[] secretKey;
+    
+    private VerifyKey verifyKey;
 
     public SigningKey(byte[] seed) {
         checkLength(seed, SECRETKEY_BYTES);
@@ -44,7 +46,7 @@ public class SigningKey {
         isValid(sodium().crypto_sign_ed25519_seed_keypair(publicKey, secretKey, seed),
                 "Failed to generate a key pair");
 
-        new VerifyKey(publicKey);
+        this.verifyKey = new VerifyKey(publicKey);
     }
 
     public SigningKey() {
@@ -53,6 +55,10 @@ public class SigningKey {
 
     public SigningKey(String seed, Encoder encoder) {
         this(encoder.decode(seed));
+    }
+    
+    public VerifyKey getVerifyKey() {
+        return this.verifyKey;
     }
 
     public byte[] sign(byte[] message) {


### PR DESCRIPTION
Exposed SigningKey's verify key and added all architectures to build in Application.mk

The VerifyKey is exposed in Kalium (non-jni), makes sense to expose it here.
The architectures is optional, but it makes life easier just following the basic documentation
