### PR TITLE
Fix javadoc-creation errors

### DIFF
--- a/src/main/java/org/abstractj/kalium/crypto/Random.java
+++ b/src/main/java/org/abstractj/kalium/crypto/Random.java
@@ -26,7 +26,7 @@ public class Random {
      * Generate random bytes
      *
      * @param n number or random bytes
-     * @return
+     * @return Byte array with random bytes
      */
     public byte[] randomBytes(int n) {
         byte[] buffer = new byte[n];

--- a/src/main/java/org/abstractj/kalium/encoders/Hex.java
+++ b/src/main/java/org/abstractj/kalium/encoders/Hex.java
@@ -19,7 +19,6 @@ package org.abstractj.kalium.encoders;
 
 /**
  * Converts hexadecimal Strings.
- * <p/>
  * This class is thread-safe.
  *
  * @version $Id$


### PR DESCRIPTION
Minor javadoc edits to fix build failure, where on previous master, 'mvn install' reports

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.8.1:jar (attach-sources) on project kalium-jni: MavenReportException: Error while creating archive:
[ERROR] Exit code: 1 - /build/kalium-jni/src/main/java/org/abstractj/kalium/crypto/Random.java:29: warning: no description for @return
[ERROR] /build/kalium-jni/src/main/java/org/abstractj/kalium/encoders/Hex.java:22: error: self-closing element not allowed
```
