### PR TITLE
Include Google Guava only in test compilation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     // TODO are these required in this lib project?
     //compile fileTree(include: ['*.jar'], dir: 'libs')
    //compile 'com.android.support:appcompat-v7:23.1.1'
-   compile group: 'com.google.guava', name: 'guava', version: '19.0'
+   testCompile group: 'com.google.guava', name: 'guava', version: '19.0'
    testCompile 'junit:junit:4.12'
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>19.0</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Google Guava library is only used for the test cases, so only include it in test compilation.