### PR TITLE
Widen the supported OSs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 9
         targetSdkVersion 23
         versionCode project.VERSION_CODE.toInteger()
         versionName project.VERSION_NAME
@@ -68,14 +68,14 @@ buildscript {
 }
 
 [
-  [input_arch: 'arm',     output_arch: 'android-armv6'   ],
-  [input_arch: 'armv7-a', output_arch: 'android-armv7-a' ],
-  [input_arch: 'armv8-a', output_arch: 'android-armv8-a' ],
-  [input_arch: 'mips32',  output_arch: 'android-mips32'  ],
-  [input_arch: 'mips64',  output_arch: 'android-mips64r6'],
-  [input_arch: 'x86',     output_arch: 'android-i686'    ],
-  [input_arch: 'x86_64',  output_arch: 'android-westmere'],
-  [                       output_arch: 'host'            ],
+  [input_arch: 'arm',     output_arch: 'android-armv6',    ndk_platform: 'android-9' ],
+  [input_arch: 'armv7-a', output_arch: 'android-armv7-a',  ndk_platform: 'android-9' ],
+  [input_arch: 'armv8-a', output_arch: 'android-armv8-a',  ndk_platform: 'android-21'],
+  [input_arch: 'mips32',  output_arch: 'android-mips32',   ndk_platform: 'android-9' ],
+  [input_arch: 'mips64',  output_arch: 'android-mips64r6', ndk_platform: 'android-21'],
+  [input_arch: 'x86',     output_arch: 'android-i686',     ndk_platform: 'android-9' ],
+  [input_arch: 'x86_64',  output_arch: 'android-westmere', ndk_platform: 'android-21'],
+  [                       output_arch: 'host'                                         ],
 ].each { opts -> 
 
   def taskname = "compileNative_${opts['output_arch']}"
@@ -89,6 +89,7 @@ buildscript {
           workingDir 'libsodium'
           executable "dist-build/android-${opts['input_arch']}.sh"
           environment 'CONFIG_SITE', '' // This makes ./configure load information about the host and guess this is information valid for the target. However, the target is Android here, the host information does not apply. 
+          environment 'NDK_PLATFORM', opts['ndk_platform'] // The lowest possible value is android-9 here. Certain Android API levels below android-16 do not have posix_memalign. This should not make a difference in practice, as android-9 has MAP_ANONYMOUS and HAVE_MMAP and posix_memalign is only used as fallback in the current libsodium code if MAP_ANONYMOUS or HAVE_MMAP are unavailable.
         }
       } else {                  // We build for the host OS and architecture
         exec {

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,3 +1,3 @@
 APP_STL := stlport_static
 
-APP_ABI := armeabi armeabi-v7a mips x86 x86_64 arm64-v8a
+APP_ABI := armeabi armeabi-v7a mips mips64 x86 x86_64 arm64-v8a

--- a/src/test/java/org/libsodium/jni/publickey/SealedBoxTest.java
+++ b/src/test/java/org/libsodium/jni/publickey/SealedBoxTest.java
@@ -49,11 +49,11 @@ public class SealedBoxTest {
 
         Sodium.crypto_box_keypair(public_key,private_key);
 
-        File public_key_file=File.createTempFile("SealedBoxTest","box_public.key");
+        File public_key_file=File.createTempFile("SealedBoxTest","box_public.key",TemporaryFile.temporaryFileDirectory());
         public_key_file.deleteOnExit();
         Files.write(public_key,public_key_file);
 
-        File private_key_file=File.createTempFile("SealedBoxTest","box_private.key");
+        File private_key_file=File.createTempFile("SealedBoxTest","box_private.key",TemporaryFile.temporaryFileDirectory());
         private_key_file.deleteOnExit();
         Files.write(private_key,private_key_file);
 

--- a/src/test/java/org/libsodium/jni/publickey/SignatureTest.java
+++ b/src/test/java/org/libsodium/jni/publickey/SignatureTest.java
@@ -73,11 +73,11 @@ public class SignatureTest {
         System.out.println(ret);
         System.out.println("Generated keypair");
 
-        File public_key_file=File.createTempFile("SignatureTest","public.key");
+        File public_key_file=File.createTempFile("SignatureTest","public.key",TemporaryFile.temporaryFileDirectory());
         public_key_file.deleteOnExit();
         Files.write(public_key,public_key_file);
 
-        File private_key_file=File.createTempFile("SignatureTest","private.key");
+        File private_key_file=File.createTempFile("SignatureTest","private.key",TemporaryFile.temporaryFileDirectory());
         private_key_file.deleteOnExit();
         Files.write(private_key,private_key_file);
 

--- a/src/test/java/org/libsodium/jni/publickey/TemporaryFile.java
+++ b/src/test/java/org/libsodium/jni/publickey/TemporaryFile.java
@@ -1,0 +1,35 @@
+package org.libsodium.jni.publickey;
+
+import java.io.File;
+
+public class TemporaryFile {
+	
+	/**
+		Cross-platform way to obtain a temporary directory.
+		
+		Under standard Java, this returns null.
+		Under Android while testing, this returns android.support.test.InstrumentationRegistry.getTargetContext().getCacheDir(). This is necessary, because the default implementation of java.io.File.createTempFile() under Android API level 10 is actually defunct.
+	*/
+	public static File temporaryFileDirectory() {
+		return temporaryFileDirectory;
+	}
+	
+	static File temporaryFileDirectory; 
+	
+	static {
+		try {
+			Class  instrumentationRegistryClass  = Class.forName("android.support.test.InstrumentationRegistry");           // Should throw ClassNotFoundException on non-Android platforms
+			Object targetContext                 = instrumentationRegistryClass.getMethod("getTargetContext").invoke(null);
+			TemporaryFile.temporaryFileDirectory = (File) (targetContext.getClass().getMethod("getCacheDir").invoke(targetContext)); 
+		} catch (NoSuchMethodException e) {
+			throw new ExceptionInInitializerError(e);
+		} catch (IllegalAccessException e) {
+			throw new ExceptionInInitializerError(e);
+		} catch (java.lang.reflect.InvocationTargetException e) {
+			throw new ExceptionInInitializerError(e);
+		} catch (ClassNotFoundException e) {
+			// No handling, as this ClassNotFoundException is expected on non-Android platforms.
+		}
+	}
+}
+


### PR DESCRIPTION
This widens the supported OSs by also allowing Android API level 9 (instead of Android API level 16) and by allowing the Android mips64 platform.