### PR TITLE
Run tests under different Android emulators.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ env:
 # - ANDROID_API=android-24 ANDROID_ABI=mips64
 matrix:
   allow_failures:
-    - env: ANDROID_API=android-10 ANDROID_ABI=armeabi-v7a # Allow ANDROID_API=android-10 ANDROID_ABI=armeabi-v7a to fail, because as of bug https://code.google.com/p/android/issues/detail?id=10255           , the ADB Server often hangs, even with workaround.
     - env: ANDROID_API=android-21 ANDROID_ABI=x86_64      # Allow ANDROID_ABI=x86_64                             to fail, because as of https://android.googlesource.com/platform/external/qemu/+/4a88987%5E!/ , x86_64 emulation currently requires KVM, and Travis does not provide KVM.
     - env: ANDROID_API=android-24 ANDROID_ABI=x86_64
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,15 +6,15 @@ env:
   - ANDROID_API=android-10 ANDROID_ABI=x86
   - ANDROID_API=android-16 ANDROID_ABI=x86
   - ANDROID_API=android-24 ANDROID_ABI=x86
-  - ANDROID_API=android-10 ANDROID_ABI=mips
+# - ANDROID_API=android-10 ANDROID_ABI=mips
   - ANDROID_API=android-16 ANDROID_ABI=mips
-  - ANDROID_API=android-24 ANDROID_ABI=mips
-  - ANDROID_API=android-21 ANDROID_ABI=arm64-v8a
+# - ANDROID_API=android-24 ANDROID_ABI=mips
+# - ANDROID_API=android-21 ANDROID_ABI=arm64-v8a
   - ANDROID_API=android-24 ANDROID_ABI=arm64-v8a
   - ANDROID_API=android-21 ANDROID_ABI=x86_64
   - ANDROID_API=android-24 ANDROID_ABI=x86_64
-  - ANDROID_API=android-21 ANDROID_ABI=mips64
-  - ANDROID_API=android-24 ANDROID_ABI=mips64
+# - ANDROID_API=android-21 ANDROID_ABI=mips64
+# - ANDROID_API=android-24 ANDROID_ABI=mips64
 os:
   - linux
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,19 @@ language: android
 env:
   - ANDROID_API=android-10 ANDROID_ABI=armeabi-v7a
   - ANDROID_API=android-16 ANDROID_ABI=armeabi-v7a
-  - ANDROID_API=android-25 ANDROID_ABI=armeabi-v7a
+  - ANDROID_API=android-24 ANDROID_ABI=armeabi-v7a
   - ANDROID_API=android-10 ANDROID_ABI=x86
   - ANDROID_API=android-16 ANDROID_ABI=x86
-  - ANDROID_API=android-25 ANDROID_ABI=x86
+  - ANDROID_API=android-24 ANDROID_ABI=x86
   - ANDROID_API=android-10 ANDROID_ABI=mips
   - ANDROID_API=android-16 ANDROID_ABI=mips
-  - ANDROID_API=android-25 ANDROID_ABI=mips
+  - ANDROID_API=android-24 ANDROID_ABI=mips
   - ANDROID_API=android-21 ANDROID_ABI=arm64-v8a
-  - ANDROID_API=android-25 ANDROID_ABI=arm64-v8a
+  - ANDROID_API=android-24 ANDROID_ABI=arm64-v8a
   - ANDROID_API=android-21 ANDROID_ABI=x86_64
-  - ANDROID_API=android-25 ANDROID_ABI=x86_64
+  - ANDROID_API=android-24 ANDROID_ABI=x86_64
   - ANDROID_API=android-21 ANDROID_ABI=mips64
-  - ANDROID_API=android-25 ANDROID_ABI=mips64
+  - ANDROID_API=android-24 ANDROID_ABI=mips64
 os:
   - linux
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: android
 env:
-  - ANDROID_API=android-9  ANDROID_ABI=armeabi-v7a
+  - ANDROID_API=android-10 ANDROID_ABI=armeabi-v7a
   - ANDROID_API=android-16 ANDROID_ABI=armeabi-v7a
   - ANDROID_API=android-25 ANDROID_ABI=armeabi-v7a
-  - ANDROID_API=android-9  ANDROID_ABI=x86
+  - ANDROID_API=android-10 ANDROID_ABI=x86
   - ANDROID_API=android-16 ANDROID_ABI=x86
   - ANDROID_API=android-25 ANDROID_ABI=x86
-  - ANDROID_API=android-9  ANDROID_ABI=mips
+  - ANDROID_API=android-10 ANDROID_ABI=mips
   - ANDROID_API=android-16 ANDROID_ABI=mips
   - ANDROID_API=android-25 ANDROID_ABI=mips
   - ANDROID_API=android-21 ANDROID_ABI=arm64-v8a

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,20 @@
 language: android
+env:
+  - ANDROID_API=android-9  ANDROID_ABI=armeabi-v7a
+  - ANDROID_API=android-16 ANDROID_ABI=armeabi-v7a
+  - ANDROID_API=android-25 ANDROID_ABI=armeabi-v7a
+  - ANDROID_API=android-9  ANDROID_ABI=x86
+  - ANDROID_API=android-16 ANDROID_ABI=x86
+  - ANDROID_API=android-25 ANDROID_ABI=x86
+  - ANDROID_API=android-9  ANDROID_ABI=mips
+  - ANDROID_API=android-16 ANDROID_ABI=mips
+  - ANDROID_API=android-25 ANDROID_ABI=mips
+  - ANDROID_API=android-21 ANDROID_ABI=arm64-v8a
+  - ANDROID_API=android-25 ANDROID_ABI=arm64-v8a
+  - ANDROID_API=android-21 ANDROID_ABI=x86_64
+  - ANDROID_API=android-25 ANDROID_ABI=x86_64
+  - ANDROID_API=android-21 ANDROID_ABI=mips64
+  - ANDROID_API=android-25 ANDROID_ABI=mips64
 os:
   - linux
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ env:
   - ANDROID_API=android-16 ANDROID_ABI=x86
   - ANDROID_API=android-24 ANDROID_ABI=x86
 # - ANDROID_API=android-10 ANDROID_ABI=mips
+  - ANDROID_API=android-15 ANDROID_ABI=mips
   - ANDROID_API=android-16 ANDROID_ABI=mips
+  - ANDROID_API=android-17 ANDROID_ABI=mips
 # - ANDROID_API=android-24 ANDROID_ABI=mips
 # - ANDROID_API=android-21 ANDROID_ABI=arm64-v8a
   - ANDROID_API=android-24 ANDROID_ABI=arm64-v8a

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ sudo: required
 before_install:
   - . ./setenv.sh
   - ./dependencies-linux.sh
-#  - ./android-emulator.sh
+  - ./android-emulator.sh
 before_script:
   - . ./setenv.sh
 script:
   - gradle build --full-stacktrace 
-#  - gradle connectedCheck --full-stacktrace
+  - gradle connectedCheck --full-stacktrace
   - travis_wait 30 ./travis.sh
 after_failure:
   - cat emulator.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,11 @@ env:
   - ANDROID_API=android-24 ANDROID_ABI=x86_64
 # - ANDROID_API=android-21 ANDROID_ABI=mips64
 # - ANDROID_API=android-24 ANDROID_ABI=mips64
+matrix:
+  allow_failures:
+    - env: ANDROID_API=android-10 ANDROID_ABI=armeabi-v7a # Allow ANDROID_API=android-10 ANDROID_ABI=armeabi-v7a to fail, because as of bug https://code.google.com/p/android/issues/detail?id=10255           , the ADB Server often hangs, even with workaround.
+    - env: ANDROID_API=android-21 ANDROID_ABI=x86_64      # Allow ANDROID_ABI=x86_64                             to fail, because as of https://android.googlesource.com/platform/external/qemu/+/4a88987%5E!/ , x86_64 emulation currently requires KVM, and Travis does not provide KVM.
+    - env: ANDROID_API=android-24 ANDROID_ABI=x86_64
 os:
   - linux
 sudo: required

--- a/android-emulator.sh
+++ b/android-emulator.sh
@@ -2,10 +2,13 @@
 
 . ./setenv.sh
 
+ANDROID_API="${ANDROID_API:-android-10}"
+ANDROID_ABI="${ANDROID_ABI:-armeabi-v7a}"
+
 cat "$(which android-wait-for-emulator)"
-echo y | sdkmanager 'system-images;android-10;default;armeabi-v7a' 'platforms;android-10'
+echo y | sdkmanager "system-images;${ANDROID_API};default;${ANDROID_ABI}" "platforms;${ANDROID_API}"
 android list targets
-echo no | android create avd --force -n test -t android-10 --abi armeabi-v7a
+echo no | android create avd --force -n test -t "${ANDROID_API}" --abi "${ANDROID_ABI}"
 emulator -avd test -no-window -memory 512 -wipe-data 2>&1 | tee emulator.log &
 adb logcat 2>&1 | tee logcat.log &
 

--- a/android-emulator.sh
+++ b/android-emulator.sh
@@ -9,7 +9,7 @@ cat "$(which android-wait-for-emulator)"
 echo y | sdkmanager "system-images;${ANDROID_API};default;${ANDROID_ABI}" "platforms;${ANDROID_API}"
 android list targets
 echo no | android create avd --force -n test -t "${ANDROID_API}" --abi "${ANDROID_ABI}"
-emulator -avd test -no-window -memory 512 -wipe-data 2>&1 | tee emulator.log &
+emulator -avd test -no-window -no-accel -memory 512 -wipe-data 2>&1 | tee emulator.log &
 adb logcat 2>&1 | tee logcat.log &
 
 # Workaround from https://code.google.com/p/android/issues/detail?id=10255#c31 to prevent the hanging of "adb shell"

--- a/android-emulator.sh
+++ b/android-emulator.sh
@@ -12,14 +12,11 @@ echo no | android create avd --force -n test -t "${ANDROID_API}" --abi "${ANDROI
 emulator -avd test -no-window -no-accel -memory 512 -wipe-data 2>&1 | tee emulator.log &
 adb logcat 2>&1 | tee logcat.log &
 
-# Workaround from https://code.google.com/p/android/issues/detail?id=10255#c31 to prevent the hanging of "adb shell"
-while true; do 
-#	echo "Pinging ADB server."
-	adb -e shell echo ping || true
-	sleep 10
-done &
-
-android-wait-for-emulator
+if [ "$ANDROID_API" = "android-10" ] && [ "$ANDROID_ABI" = "armeabi-v7a" ]; then
+	sleep 240 # android-wait-for-emulator hangs for ANDROID_API=android-10 ANDROID_ABI=armeabi-v7a, so we wait and hope the emulator has started during that time.
+else
+	android-wait-for-emulator
+fi
 
 # Replace /dev/random by /dev/urandom in order to make accessing /dev/random not block during testing.
 # This is only to augment the synthetic testing environment.

--- a/android-emulator.sh
+++ b/android-emulator.sh
@@ -20,3 +20,9 @@ while true; do
 done &
 
 android-wait-for-emulator
+
+# Replace /dev/random by /dev/urandom in order to make accessing /dev/random not block during testing.
+# This is only to augment the synthetic testing environment.
+# Do not use this in production, as that this makes the perceived randomness actually non-random. 
+adb -e shell 'rm /dev/random; ln -s /dev/urandom /dev/random' || true # This may fail for Android-25, but it is not needed for Android-25
+

--- a/android-emulator.sh
+++ b/android-emulator.sh
@@ -8,5 +8,12 @@ android list targets
 echo no | android create avd --force -n test -t android-10 --abi armeabi-v7a
 emulator -avd test -no-window -memory 512 -wipe-data 2>&1 | tee emulator.log &
 adb logcat 2>&1 | tee logcat.log &
-bash -x "$(which android-wait-for-emulator)"
+
+# Workaround from https://code.google.com/p/android/issues/detail?id=10255#c31 to prevent the hanging of "adb shell"
+while true; do 
+#	echo "Pinging ADB server."
+	adb -e shell echo ping || true
+	sleep 10
+done &
+
 android-wait-for-emulator

--- a/android-emulator.sh
+++ b/android-emulator.sh
@@ -6,7 +6,7 @@ ANDROID_API="${ANDROID_API:-android-10}"
 ANDROID_ABI="${ANDROID_ABI:-armeabi-v7a}"
 
 cat "$(which android-wait-for-emulator)"
-echo y | sdkmanager "system-images;${ANDROID_API};default;${ANDROID_ABI}" "platforms;${ANDROID_API}"
+while true; do echo y; sleep 3; done | sdkmanager "system-images;${ANDROID_API};default;${ANDROID_ABI}" "platforms;${ANDROID_API}"
 android list targets
 echo no | android create avd --force -n test -t "${ANDROID_API}" --abi "${ANDROID_ABI}"
 emulator -avd test -no-window -no-accel -memory 512 -wipe-data 2>&1 | tee emulator.log &


### PR DESCRIPTION
This change makes the tests run under several different emulators.

It also works around a bug where ADB hangs. This bug seems to happen only on a particular combination of emulator API version and emulator ABI version, though.