### PR TITLE
Make gradle build caching work again.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ buildscript {
   def taskname = "compileNative_${opts['output_arch']}"
   
   task(taskname) {
-    inputs.dir  fileTree(dir: 'libsodium/src', exclude: ['libsodium/**/.libs', 'libsodium/*.la', 'libsodium/**/*.lo', 'libsodium/**/*.o', 'libsodium/**/*.Plo', '**/Makefile'])
+    inputs.dir  fileTree(dir: 'libsodium/src', exclude: ['libsodium/**/.libs', 'libsodium/*.la', 'libsodium/**/*.lo', 'libsodium/**/*.o', 'libsodium/**/*.Plo', '**/Makefile', '**/Makefile.in', '**/.deps/*', '**/.libs/*'])
     outputs.dir("libsodium/libsodium-${opts['output_arch']}")
     doFirst {
       if (opts['input_arch']) { // We build for an explicit OS and architecture


### PR DESCRIPTION
Build caching (that is: preventing a recompile when not necessary) currently fails because the native compilation procedure repeatedly auto-generates files within "libsodium/src", changing their timestamp and making gradle believe that some source file has changed.

This patch fixes that problem.