### PR TITLE
Support gradle multi-project builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,10 @@
 apply plugin: 'maven'
 apply plugin: 'com.android.library'
 apply plugin: 'signing'
-apply plugin: 'io.codearte.nexus-staging'
+
+if (project==rootProject) {
+    apply plugin: 'io.codearte.nexus-staging'
+}
 
 repositories {
     mavenCentral()
@@ -264,6 +267,9 @@ signing {
     sign configurations.archives
 }
 
-nexusStaging {
-    packageGroup = "com.github.joshjdevl"
+if (project==rootProject) {
+    nexusStaging {
+        packageGroup = "com.github.joshjdevl"
+    }
 }
+


### PR DESCRIPTION
As libsodium-jni is a library, its purpose is to be included into other projects. One way of doing this is using the Multi-project Builds feature of Gradle. However, this currently fails, as the "nexus-staging" plugin is activated, and this plugin does not support being used in a project which is not a Gradle root project but a Gradle sub-project.

Hence, this plugin should be disabled in case the libsodium-jni project is used as a Gradle sub-project.

This fixes the problem that libsodium-jni was not usable as a Gradle sub-project.