### PR TITLE
feat: Add key exchange sodium methods

### DIFF
--- a/jni/sodium.i
+++ b/jni/sodium.i
@@ -613,7 +613,28 @@ int crypto_onetimeauth_update(crypto_onetimeauth_state *dst_state,
 int crypto_onetimeauth_final(crypto_onetimeauth_state *final_state,
                              unsigned char *dst_out);
 
+/*
+    Key exchange
+*/
 
+int crypto_kx_keypair(unsigned char *pk,
+                      unsigned char *sk);
+
+int crypto_kx_seed_keypair(unsigned char *pk,
+                           unsigned char *sk,
+                           const unsigned char *seed);
+
+int crypto_kx_client_session_keys(unsigned char *rx,
+                                  unsigned char *tx,
+                                  const unsigned char *client_pk,
+                                  const unsigned char *client_sk,
+                                  const unsigned char *server_pk);
+
+int crypto_kx_server_session_keys(unsigned char *rx,
+                                  unsigned char *tx,
+                                  const unsigned char *server_pk,
+                                  const unsigned char *server_sk,
+                                  const unsigned char *client_pk);
 
 /* *****************************************************************************
 

--- a/src/main/java/org/libsodium/jni/Sodium.java
+++ b/src/main/java/org/libsodium/jni/Sodium.java
@@ -1069,4 +1069,20 @@ public class Sodium {
     return SodiumJNI.crypto_stream_xsalsa20_xor_ic(c, m, mlen, n, ic, k);
   }
 
+  public static int crypto_kx_client_session_keys(byte[] rx, byte[] tx, byte[] client_pk, byte[] client_sk, byte[] server_pk) {
+    return SodiumJNI.crypto_kx_client_session_keys(rx, tx, client_pk, client_sk, server_pk);
+  }
+
+  public static int crypto_kx_server_session_keys(byte[] rx, byte[] tx, byte[] server_pk, byte[] server_sk, byte[] client_pk) {
+    return SodiumJNI.crypto_kx_server_session_keys(rx, tx, server_pk, server_sk, client_pk);
+  }
+
+  public static int crypto_kx_keypair(byte[] pk, byte[] sk) {
+    return SodiumJNI.crypto_kx_keypair(pk, sk);
+  }
+
+  public static int crypto_kx_seed_keypair(byte[] pk, byte[] sk, byte[] seed) {
+    return SodiumJNI.crypto_kx_seed_keypair(pk, sk, seed);
+  }
+
 }

--- a/src/main/java/org/libsodium/jni/SodiumConstants.java
+++ b/src/main/java/org/libsodium/jni/SodiumConstants.java
@@ -23,4 +23,5 @@ public abstract class SodiumConstants {
     public static final int AEAD_CHACHA20_POLY1305_KEYBYTES = 32;
     public static final int AEAD_CHACHA20_POLY1305_NPUBBYTES = 8;
     public static final int AEAD_CHACHA20_POLY1305_ABYTES = 8;
+    public static final int SESSIONKEYBYTES = 32;
 }

--- a/src/main/java/org/libsodium/jni/SodiumJNI.java
+++ b/src/main/java/org/libsodium/jni/SodiumJNI.java
@@ -274,4 +274,8 @@ public class SodiumJNI {
   public final static native int crypto_stream_xsalsa20_noncebytes();
   public final static native int crypto_stream_xsalsa20_xor(byte[] jarg1, byte[] jarg2, int jarg3, byte[] jarg4, byte[] jarg5);
   public final static native int crypto_stream_xsalsa20_xor_ic(byte[] jarg1, byte[] jarg2, int jarg3, byte[] jarg4, int jarg5, byte[] jarg6);
+  public final static native int crypto_kx_client_session_keys(byte[] jarg1,  byte[] jarg2, byte[] jarg3, byte[] jarg4, byte[] jarg5);
+  public final static native int crypto_kx_server_session_keys(byte[] jarg1,  byte[] jarg2, byte[] jarg3, byte[] jarg4, byte[] jarg5);
+  public final static native int crypto_kx_keypair(byte[] jarg1,  byte[] jarg2);
+  public final static native int crypto_kx_seed_keypair(byte[] jarg1,  byte[] jarg2, byte[] jarg3);
 }

--- a/src/test/java/org/libsodium/jni/crypto/KeyExchangeTest.java
+++ b/src/test/java/org/libsodium/jni/crypto/KeyExchangeTest.java
@@ -1,0 +1,50 @@
+package org.libsodium.jni.crypto;
+
+import org.junit.Test;
+import org.libsodium.jni.Sodium;
+import org.libsodium.jni.encoders.Hex;
+
+import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
+import static org.libsodium.jni.SodiumConstants.PUBLICKEY_BYTES;
+import static org.libsodium.jni.SodiumConstants.SESSIONKEYBYTES;
+
+public class KeyExchangeTest {
+
+    @Test
+    public void testClientServerKeyExchange() {
+        byte[] server_pk = new byte[PUBLICKEY_BYTES];
+        byte[] server_sk = new byte[SESSIONKEYBYTES];
+        byte[] client_pk = new byte[PUBLICKEY_BYTES];
+        byte[] client_sk = new byte[SESSIONKEYBYTES];
+
+        assertEquals(Sodium.crypto_kx_keypair(server_pk, server_sk), 0);
+        assertEquals(Sodium.crypto_kx_keypair(client_pk, client_sk), 0);
+
+        byte[] server_rx = new byte[SESSIONKEYBYTES];
+        byte[] server_tx = new byte[SESSIONKEYBYTES];
+        byte[] client_rx = new byte[SESSIONKEYBYTES];
+        byte[] client_tx = new byte[SESSIONKEYBYTES];
+
+        assertEquals(Sodium.crypto_kx_server_session_keys(server_rx, server_tx, server_pk, server_sk, client_pk), 0);
+        assertEquals(Sodium.crypto_kx_client_session_keys(client_rx, client_tx, client_pk, client_sk, server_pk), 0);
+
+        assertArrayEquals(server_rx, client_tx);
+        assertArrayEquals(server_tx, client_rx);
+    }
+
+    @Test
+    public void testServerSessionKeyExchange() {
+        Hex hex = new Hex();
+        byte[] rx = new byte[SESSIONKEYBYTES];
+        byte[] tx = new byte[SESSIONKEYBYTES];
+
+        byte[] server_pk = hex.decode("f61788dd49d78f061a48adf45128be1693f6099c52d3cb9ae69f87b7ba11620c");
+        byte[] server_sk = hex.decode("a7a91bbe84f15da821a5421d2a96c93c575138dee2bbaca11a818e5aeed72a49");
+        byte[] client_pk = hex.decode("dc2efbd4fcdc2c4f8e8ae87ae4806d1f96b1d27e10cf1f44b2d8992c65cac41b");
+
+        assertEquals(Sodium.crypto_kx_server_session_keys(rx, tx, server_pk, server_sk, client_pk), 0);
+        assertEquals(hex.encode(rx), "09bae6d4fc5b2dbc48558c8c8a4e67dcf6611561aaea6a16897bcb8aa23d4fa1");
+        assertEquals(hex.encode(tx), "79b5fe6746853894f60d76e40487072c2af8ef01c1b34d606e804b5d3dab1de9");
+    }
+}


### PR DESCRIPTION
I found crypto_kx.h header, but no implementation for last high-level key exchange methods 
https://download.libsodium.org/doc/key_exchange/
Not sure about the right way to implement, but these methods are very necessary