### PR TITLE
Honour the user's JAVA_HOME; build breaks under JDK 9.

### DIFF
--- a/setenv.sh
+++ b/setenv.sh
@@ -6,7 +6,7 @@ export ANDROID_SDK_VERSION=r26.0.2
 export CLANG_VERSION=5.0
 
 if uname -a | grep -q -i darwin; then
-    export JAVA_HOME=$(/usr/libexec/java_home)
+    export JAVA_HOME=${JAVA_HOME:-$(/usr/libexec/java_home)}
     export ANDROID_NDK=/usr/local/share/android-ndk
     export ANDROID_NDK_HOME=/usr/local/share/android-ndk
     export ANDROID_SDK=/usr/local/share/android-sdk


### PR DESCRIPTION
Building Android artifacts currently does not work under JDK 9.  If a user has JDK 9 installed, `java_home` defaults to this when the script resolves a path for `JAVA_HOME`.  The result is that even if the user has JDK 8 installed, the code cannot build without uninstalling JDK 9.

At the root of the problem here lies the fact that the build script overrides the user's own `JAVA_HOME` configuration.  As such, a user cannot set JDK 8 as their default JDK by setting its path in their `JAVA_HOME` because the build script just ignores and overwrites it.

This commit respects the user's `JAVA_HOME` if it is set.

An alternative solution (and not mutually exclusive, just not implemented here) would be use `java_home -v 1.8*` instead of just `java_home`.  This would force JDK 8 even if 9 is installed.  I opted against that in my pull request since I think it's better (and more forward-thinking) to be independent of a static JDK version, even if at this point in time, JDK 9 cannot build Android.  But I leave that to you to consider.