### PR TITLE
No mips

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,13 +9,14 @@ if (project==rootProject) {
 }
 
 repositories {
-    mavenCentral()
     mavenLocal()
+    mavenCentral()
+    jcenter()
+    google()
 }
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
 
     defaultConfig {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -74,7 +75,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.3'
+        classpath 'com.android.tools.build:gradle:3.1.2'
         classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.11.0"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -83,8 +83,6 @@ buildscript {
   [input_arch: 'arm',     output_arch: 'android-armv6',    ndk_platform: 'android-16' ],
   [input_arch: 'armv7-a', output_arch: 'android-armv7-a',  ndk_platform: 'android-16' ],
   [input_arch: 'armv8-a', output_arch: 'android-armv8-a',  ndk_platform: 'android-21'],
-  [input_arch: 'mips32',  output_arch: 'android-mips32',   ndk_platform: 'android-16' ],
-  [input_arch: 'mips64',  output_arch: 'android-mips64r6', ndk_platform: 'android-21'],
   [input_arch: 'x86',     output_arch: 'android-i686',     ndk_platform: 'android-16' ],
   [input_arch: 'x86_64',  output_arch: 'android-westmere', ndk_platform: 'android-21'],
   [                       output_arch: 'host'                                         ],

--- a/build.sh
+++ b/build.sh
@@ -20,10 +20,6 @@ date
 date
 ./dist-build/android-armv8-a.sh
 date
-./dist-build/android-mips32.sh
-date
-./dist-build/android-mips64.sh
-date
 ./dist-build/android-x86.sh 
 date
 ./dist-build/android-x86_64.sh

--- a/download-gradle.sh
+++ b/download-gradle.sh
@@ -18,4 +18,3 @@ mkdir -p ${ANDROID_HOME}/licenses
 echo 8933bad161af4178b1185d1a37fbf41ea5269c55 > ${ANDROID_HOME}/licenses/android-sdk-license
 echo 601085b94cd77f0b54ff86406957099ebe79c4d6 > ${ANDROID_HOME}/licenses/android-googletv-license
 echo 33b6a2b64607f11b759f320ef9dff4ae5c47d97a > ${ANDROID_HOME}/licenses/google-gdk-license
-echo e9acab5b5fbb560a72cfaecce8946896ff6aab9d > ${ANDROID_HOME}/licenses/mips-android-sysimage-license

--- a/example/Sodium/build.gradle
+++ b/example/Sodium/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
+        classpath 'com.android.tools.build:gradle:3.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -17,7 +17,6 @@ LOCAL_PATH := $(call my-dir)
 LIB_FOLDER := lib
 # Bugfix for arm, which should refer to the armv6 folder
 # Bugfix for x86, which should refer to the i686 folder
-# Bugfix for mips, which should refer to the mips32 folder
 MY_ARCH_FOLDER := $(TARGET_ARCH)
 ifeq ($(MY_ARCH_FOLDER),arm)
     MY_ARCH_FOLDER = armv6
@@ -31,17 +30,11 @@ endif
 ifeq ($(MY_ARCH_FOLDER),x86_64)
     MY_ARCH_FOLDER = westmere
 endif
-ifeq ($(MY_ARCH_FOLDER),mips)
-    MY_ARCH_FOLDER = mips32
-endif
-ifeq ($(MY_ARCH_FOLDER),mips64)
-    MY_ARCH_FOLDER = mips64r6
-endif
 
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := sodium
-LOCAL_SRC_FILES := $(abspath $(LOCAL_PATH))/../libsodium/libsodium-android-$(MY_ARCH_FOLDER)/$(LIB_FOLDER)/libsodium.a #/installs/libsodium/libsodium-android-(x86|arm|mips)/lib/libsodium.a
+LOCAL_SRC_FILES := $(abspath $(LOCAL_PATH))/../libsodium/libsodium-android-$(MY_ARCH_FOLDER)/$(LIB_FOLDER)/libsodium.a #/installs/libsodium/libsodium-android-(x86|arm)/lib/libsodium.a
 LOCAL_LDFLAGS  += -fPIC
 #LOCAL_LDLIBS   += -Wl,--no-warn-shared-textrel
 LOCAL_DISABLE_FATAL_LINKER_WARNINGS := true

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -2,4 +2,4 @@ APP_STL := c++_static
 
 APP_PLATFORM := android-16
 
-APP_ABI := armeabi armeabi-v7a mips mips64 x86 x86_64 arm64-v8a
+APP_ABI := armeabi armeabi-v7a x86 x86_64 arm64-v8a


### PR DESCRIPTION
The current Android NDK no longer supports building MIPS:

```
make_standalone_toolchain.py: error: argument --arch: invalid choice: 'mips' (choose from 'arm', 'arm64', 'x86', 'x86_64')
```

In order to fix the build, I've had to remove the references to the deprecated MIPS architecture.

I've also had to update the gradle plugin, since the old version isn't aware of the NDK architecture limitations.