### PR TITLE
Stable sodium

### DIFF
--- a/build-kaliumjni.sh
+++ b/build-kaliumjni.sh
@@ -2,8 +2,6 @@
 
 . ./setenv.sh
 
-sudo cp ./libsodium/libsodium-host/lib/libsodium.so /usr/local/lib
-
 pushd jni
 ./compile.sh
 popd

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -12,8 +12,6 @@ gradle build --full-stacktrace
 pushd jni
 ./jnilib.sh
 popd
-
-sudo cp ./libsodium/libsodium-host/lib/libsodium.so /usr/lib
 mvn -q clean install
 ./singleTest.sh
 

--- a/build-linux.sh
+++ b/build-linux.sh
@@ -4,8 +4,6 @@
 
 ./submodule-update.sh
 
-export LIBSODIUM_FULL_BUILD="true"
-
 gradle generateSWIGsource --full-stacktrace
 gradle build --full-stacktrace
 

--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,7 @@ buildscript {
         exec {
           workingDir 'libsodium'
           executable "dist-build/android-${opts['input_arch']}.sh"
+          environment 'LIBSODIUM_FULL_BUILD', 'true'
           environment 'CONFIG_SITE', '' // This makes ./configure load information about the host and guess this is information valid for the target. However, the target is Android here, the host information does not apply. 
           //environment 'NDK_PLATFORM', opts['ndk_platform'] // The lowest possible value is android-9 here. Certain Android API levels below android-16 do not have posix_memalign. This should not make a difference in practice, as android-9 has MAP_ANONYMOUS and HAVE_MMAP and posix_memalign is only used as fallback in the current libsodium code if MAP_ANONYMOUS or HAVE_MMAP are unavailable.
         }

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,8 @@ pushd libsodium
 
 ./autogen.sh
 ./configure --quiet
-make --quiet && make --quiet check 
+make --quiet
+make --quiet check 
 
 date
 ./dist-build/android-arm.sh 

--- a/build.sh
+++ b/build.sh
@@ -9,9 +9,10 @@ set -ev
 pushd libsodium
 
 ./autogen.sh
-./configure --quiet
+./configure --disable-soname-versions --prefix="$PWD/libsodium-host" --libdir="$PWD/libsodium-host/lib"
 make --quiet
 make --quiet check 
+make -j3 install
 
 date
 ./dist-build/android-arm.sh 

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,6 @@ pushd libsodium
 ./autogen.sh
 ./configure --quiet
 make --quiet && make --quiet check 
-sudo make --quiet install
 
 date
 ./dist-build/android-arm.sh 

--- a/jni/jnilib.sh
+++ b/jni/jnilib.sh
@@ -1,23 +1,4 @@
 #!/bin/bash -ev
 
-jnilib=libsodiumjni.so
-destlib=/usr/lib
-if uname -a | grep -q -i darwin; then
-  jnilib=libsodiumjni.jnilib
-  destlib=/Library/Java/Extensions
-  if [ ! -d $destlib ]; then
-      sudo mkdir $destlib
-  fi
-else
-  sudo ldconfig
-fi
-echo $jnilib
-echo $destlib
-echo $destlib/$jnilib 
-
-#sudo cp /usr/local/lib/libsodium.* /usr/lib
-
 gcc -I../libsodium/src/libsodium/include -I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux -I${JAVA_HOME}/include/darwin sodium_wrap.c -shared -fPIC -L ../libsodium/libsodium-host/lib -L/usr/local/lib -L/usr/lib -lsodium -o $jnilib
-sudo rm -f $destlib/$jnilib
-sudo cp $jnilib $destlib
 

--- a/setenv.sh
+++ b/setenv.sh
@@ -27,3 +27,4 @@ fi
 #export PATH=/usr/lib/llvm-${CLANG_VERSION}/bin:$PATH
 export PATH=${ANDROID_HOME}/emulator:$ANDROID_HOME/bin:${ANDROID_HOME}/tools:${ANDROID_HOME}/tools/bin:${ANDROID_HOME}/platform-tools:${ANDROID_NDK_HOME}:$PATH
 
+export LIBSODIUM_FULL_BUILD="true"

--- a/submodule-update.sh
+++ b/submodule-update.sh
@@ -4,8 +4,6 @@ set -ev
 
 . ./setenv.sh
 
-rm -rf libsodium
-
 git submodule init
 git submodule sync
 #git submodule update --remote --merge
@@ -13,6 +11,8 @@ git submodule update
 
 pushd libsodium
 git reset --hard
+#git clean -fdx # Uncomment to force full rebuild
+
 #git fetch && git checkout stable
 #git reset --hard origin/stable
 #git pull

--- a/submodule-update.sh
+++ b/submodule-update.sh
@@ -4,16 +4,9 @@ set -ev
 
 . ./setenv.sh
 
+( cd libsodium && git reset --hard )
+
 git submodule init
 git submodule sync
 #git submodule update --remote --merge
 git submodule update
-
-pushd libsodium
-git reset --hard
-#git clean -fdx # Uncomment to force full rebuild
-
-#git fetch && git checkout stable
-#git reset --hard origin/stable
-#git pull
-popd

--- a/submodule-update.sh
+++ b/submodule-update.sh
@@ -12,8 +12,8 @@ git submodule sync
 git submodule update
 
 pushd libsodium
-
-git fetch && git checkout stable
-git reset --hard origin/stable
-git pull
+git reset --hard
+#git fetch && git checkout stable
+#git reset --hard origin/stable
+#git pull
 popd


### PR DESCRIPTION
There are a bunch of changes here:

1. I've killed all code that installs files into the system paths.  Building some code should never pollute a user's system.  The fact that `sudo` is required is a red flag for this.  A lot of this stuff was potentially overwriting existing system files (such as my local and independent install of libsodium through homebrew).
2. `LIBSODIUM_FULL_BUILD` is now required but was not consistently set for all builds & platforms.
3. `build.sh`'s native build was conflicting with its android architecture builds.  I've updated it to match `gradle.build`'s approach, which is to build it into the `host` prefix.  Why is this build code duplicated?  We should probably kill `build.sh`?
4. No more blind deleting `libsodium` & refetching on build.  This was pointlessly excessive & expensive.  Most likely, this was necessary because of `build.sh`'s bad behavior of building the native build without a prefix (see [3]).