### PR TITLE
decrypted array size length calculation change

### DIFF
--- a/src/test/java/org/libsodium/jni/publickey/AuthenticatedEncryptionTest.java
+++ b/src/test/java/org/libsodium/jni/publickey/AuthenticatedEncryptionTest.java
@@ -44,7 +44,7 @@ public class AuthenticatedEncryptionTest {
         ret=Sodium.crypto_box_easy(ciphertext,message,message.length,nonce,bob_public_key,alice_private_key);
         Assert.assertEquals(0,ret);
 
-        byte[] decrypted=new byte[message.length];
+        byte[] decrypted=new byte[Sodium.crypto_box_macbytes() - ciphertext];
         ret=Sodium.crypto_box_open_easy(decrypted, ciphertext, (int)ciphertextlen, nonce,
                 alice_public_key, bob_private_key);
         Assert.assertEquals(0,ret);


### PR DESCRIPTION
- Since at the time of decrypting we won't be having original message object we won't be able to calculate the size of decrypted msg
- encrypted payload size is `Sodium.crypto_box_macbytes()+message.length` so if we remove `Sodium.crypto_box_macbytes()` from `ciphertext` then we can derive original size of `decrypted` array. 

