### PR TITLE
Add Key Derivation functions

### DIFF
--- a/jni/sodium.i
+++ b/jni/sodium.i
@@ -651,6 +651,20 @@ int crypto_kx_server_session_keys(unsigned char *rx,
                                   const unsigned char *server_sk,
                                   const unsigned char *client_pk);
 
+
+/*
+    Key derivation
+*/
+
+void crypto_kdf_keygen(unsigned char *key);
+
+int crypto_kdf_derive_from_key(unsigned char *subkey,
+                               const size_t subkey_len,
+                               unsigned long long subkey_id,
+                               const char *ctx,
+                               const unsigned char *key);
+                               
+
 /* *****************************************************************************
 
     LOW LEVEL API'S

--- a/src/main/java/org/libsodium/jni/Sodium.java
+++ b/src/main/java/org/libsodium/jni/Sodium.java
@@ -401,6 +401,14 @@ public class Sodium {
     return SodiumJNI.crypto_kx_server_session_keys(rx, tx, server_pk, server_sk, client_pk);
   }
 
+  public static void crypto_kdf_keygen(byte[] key) {
+    SodiumJNI.crypto_kdf_keygen(key);
+  }
+
+  public static int crypto_kdf_derive_from_key(byte[] subkey, int subkey_len, int subkey_id, byte[] ctx, byte[] key) {
+    return SodiumJNI.crypto_kdf_derive_from_key(subkey, subkey_len, subkey_id, ctx, key);
+  }
+
   public static int crypto_aead_chacha20poly1305_keybytes() {
     return SodiumJNI.crypto_aead_chacha20poly1305_keybytes();
   }

--- a/src/main/java/org/libsodium/jni/SodiumJNI.java
+++ b/src/main/java/org/libsodium/jni/SodiumJNI.java
@@ -107,6 +107,8 @@ public class SodiumJNI {
   public final static native int crypto_kx_seed_keypair(byte[] jarg1, byte[] jarg2, byte[] jarg3);
   public final static native int crypto_kx_client_session_keys(byte[] jarg1, byte[] jarg2, byte[] jarg3, byte[] jarg4, byte[] jarg5);
   public final static native int crypto_kx_server_session_keys(byte[] jarg1, byte[] jarg2, byte[] jarg3, byte[] jarg4, byte[] jarg5);
+  public final static native void crypto_kdf_keygen(byte[] jarg1);
+  public final static native int crypto_kdf_derive_from_key(byte[] jarg1, int jarg2, int jarg3, byte[] jarg4, byte[] jarg5);
   public final static native int crypto_aead_chacha20poly1305_keybytes();
   public final static native int crypto_aead_chacha20poly1305_nsecbytes();
   public final static native int crypto_aead_chacha20poly1305_npubbytes();


### PR DESCRIPTION
I need to use key derivation functions for a project, but they aren't supported. This adds them, but with no additional testing/support/etc (just the primitives).