### PR TITLE
Add crypto_kdf constants

### DIFF
--- a/jni/sodium.i
+++ b/jni/sodium.i
@@ -651,19 +651,24 @@ int crypto_kx_server_session_keys(unsigned char *rx,
                                   const unsigned char *server_sk,
                                   const unsigned char *client_pk);
 
-
 /*
-    Key derivation
+    Key Derivation
 */
 
-void crypto_kdf_keygen(unsigned char *key);
+size_t crypto_kdf_bytes_min(void);
+size_t crypto_kdf_bytes_max(void);
+size_t crypto_kdf_keybytes(void);
+size_t crypto_kdf_contextbytes(void);
+
+const char * crypto_kdf_primitive(void);
 
 int crypto_kdf_derive_from_key(unsigned char *subkey,
                                const size_t subkey_len,
                                unsigned long long subkey_id,
                                const char *ctx,
                                const unsigned char *key);
-                               
+
+void crypto_kdf_keygen(unsigned char *key);
 
 /* *****************************************************************************
 

--- a/src/main/java/org/libsodium/jni/Sodium.java
+++ b/src/main/java/org/libsodium/jni/Sodium.java
@@ -401,12 +401,32 @@ public class Sodium {
     return SodiumJNI.crypto_kx_server_session_keys(rx, tx, server_pk, server_sk, client_pk);
   }
 
-  public static void crypto_kdf_keygen(byte[] key) {
-    SodiumJNI.crypto_kdf_keygen(key);
+  public static int crypto_kdf_bytes_min() {
+    return SodiumJNI.crypto_kdf_bytes_min();
+  }
+
+  public static int crypto_kdf_bytes_max() {
+    return SodiumJNI.crypto_kdf_bytes_max();
+  }
+
+  public static int crypto_kdf_keybytes() {
+    return SodiumJNI.crypto_kdf_keybytes();
+  }
+
+  public static int crypto_kdf_contextbytes() {
+    return SodiumJNI.crypto_kdf_contextbytes();
+  }
+
+  public static byte[] crypto_kdf_primitive() {
+    return SodiumJNI.crypto_kdf_primitive();
   }
 
   public static int crypto_kdf_derive_from_key(byte[] subkey, int subkey_len, int subkey_id, byte[] ctx, byte[] key) {
     return SodiumJNI.crypto_kdf_derive_from_key(subkey, subkey_len, subkey_id, ctx, key);
+  }
+
+  public static void crypto_kdf_keygen(byte[] key) {
+    SodiumJNI.crypto_kdf_keygen(key);
   }
 
   public static int crypto_aead_chacha20poly1305_keybytes() {

--- a/src/main/java/org/libsodium/jni/SodiumJNI.java
+++ b/src/main/java/org/libsodium/jni/SodiumJNI.java
@@ -107,8 +107,13 @@ public class SodiumJNI {
   public final static native int crypto_kx_seed_keypair(byte[] jarg1, byte[] jarg2, byte[] jarg3);
   public final static native int crypto_kx_client_session_keys(byte[] jarg1, byte[] jarg2, byte[] jarg3, byte[] jarg4, byte[] jarg5);
   public final static native int crypto_kx_server_session_keys(byte[] jarg1, byte[] jarg2, byte[] jarg3, byte[] jarg4, byte[] jarg5);
-  public final static native void crypto_kdf_keygen(byte[] jarg1);
+  public final static native int crypto_kdf_bytes_min();
+  public final static native int crypto_kdf_bytes_max();
+  public final static native int crypto_kdf_keybytes();
+  public final static native int crypto_kdf_contextbytes();
+  public final static native byte[] crypto_kdf_primitive();
   public final static native int crypto_kdf_derive_from_key(byte[] jarg1, int jarg2, int jarg3, byte[] jarg4, byte[] jarg5);
+  public final static native void crypto_kdf_keygen(byte[] jarg1);
   public final static native int crypto_aead_chacha20poly1305_keybytes();
   public final static native int crypto_aead_chacha20poly1305_nsecbytes();
   public final static native int crypto_aead_chacha20poly1305_npubbytes();


### PR DESCRIPTION
I did a PR with the kdf functions a while ago but didn't include the constants. I figure it's probably better to include them than hardcode them into my code...

Also makes ordering the same as in libsodium's source for crypto_kdf_keygen and crypto_kdf_derive_from_key.