### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,16 +18,16 @@ matrix:
       - os: linux
         services: docker
         script:
-          - travis_retry docker build .
+          - docker build .
       - os: linux
         dist: trusty
         sudo: required
         before_script:
           - . ./setenv.sh
         before_install:
-          - travis_retry travis_wait 120 ./dependencies.sh
+          - ./dependencies.sh
         script:
-          - travis_wait 120 ./travis.sh
+          - ./travis.sh
       - os: osx
         osx_image: xcode9.2
         cache:
@@ -38,8 +38,7 @@ matrix:
           - . ./setenv.sh
         before_install:
           - brew install ccache
-          - travis_wait 120 ./dependencies.sh
+          - ./dependencies.sh
         script:
           - export PATH="/usr/local/opt/ccache/libexec:$PATH"
-          - travis_wait 120 ./travis.sh
-
+          - ./travis.sh


### PR DESCRIPTION

Does travis_retry really solve the build issues? According to the data in paper [An empirical study of the long duration of continuous integration builds](https://dl.acm.org/doi/10.1007/s10664-019-09695-9), travis_retry can only solve 3% of the build failures. And it may cause unstable build and increase build time.

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
